### PR TITLE
feat(agolia): implement the agolia search of laravel

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,39 @@
-from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
+from ulauncher.api.client.Extension import Extension
+from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
+from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
 from ulauncher.api.shared.event import KeywordQueryEvent
 from ulauncher.api.shared.item.ExtensionResultItem import ExtensionResultItem
-from ulauncher.api.shared.action.RenderResultListAction import RenderResultListAction
-from ulauncher.api.shared.action.OpenUrlAction import OpenUrlAction
+import logging
+
+# create an instance of logger at a module level
+logger = logging.getLogger(__name__)
+
+try:
+    from algoliasearch.search_client import SearchClient
+except ImportError:
+    import subprocess
+    import sys
+    import os
+
+    subprocess.call([sys.executable, '-m', 'pip', 'install', '--user', '-r',
+                     os.path.join(os.path.dirname(__file__), 'requirements.txt')])
+
+    from algoliasearch.search_client import SearchClient
+
+
+def get_subtitle(hit):
+    if hit["h4"] is not None:
+        return hit["h4"]
+
+    if hit["h3"] is not None:
+        return hit["h3"]
+
+    if hit["h2"] is not None:
+        return hit["h2"]
+
+    return ''
+
 
 class LaravelExtension(Extension):
 
@@ -11,27 +41,39 @@ class LaravelExtension(Extension):
         super(LaravelExtension, self).__init__()
 
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
+        agolia = SearchClient.create("8BB87I11DE", "8e1d446d61fce359f69cd7c8b86a50de")
+        self.index = agolia.init_index("docs")
 
 
 class KeywordQueryEventListener(EventListener):
 
     def on_event(self, event, extension):
-
         description = "Type in your query and press Enter..."
 
         url = "https://laravel.com/docs/"
-
-        if event.get_argument() != None:
-            description = url + event.get_argument()
-
-        return RenderResultListAction([
-            ExtensionResultItem(
-                icon='icons/laravel.svg',
-                name='Laravel Search',
-                description=description,
-                on_enter=OpenUrlAction(url + (event.get_argument() or ''))
+        extension_results = []
+        if event.get_argument() is not None:
+            results = extension.index.search(
+                event.get_argument(), {"tagFilters": "master", "hitsPerPage": 5}
             )
-        ])
+
+            for hit in results["hits"]:
+                extension_results.append(ExtensionResultItem(
+                    icon='icons/laravel.svg',
+                    name=hit["h1"],
+                    description=get_subtitle(hit),
+                    on_enter=OpenUrlAction(url + hit["link"])
+                ))
+        if len(extension_results) == 0:
+            extension_results.append(ExtensionResultItem(
+                icon='icons/laravel.svg',
+                name="Search Laravel docs",
+                description=description,
+                on_enter=OpenUrlAction(url)
+            ))
+
+        return RenderResultListAction(extension_results)
+
 
 if __name__ == '__main__':
     LaravelExtension().run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+algoliasearch==2.4.0
+certifi==2020.12.5
+chardet==4.0.0
+idna==2.10
+requests==2.25.1
+urllib3==1.26.4


### PR DESCRIPTION
Hi.

I've recently switched from [albert launcher](https://albertlauncher.github.io/) to ULauch.

Albert launcher had an [extension](https://github.com/rickwest/albert-laravel-docs) that uses the search api of Agolia that is used in the laravel documentation pages.

Here, I've implemented the same functionality in your extension.

Let me know if I missed something. 